### PR TITLE
RemoveSnapshot extraction to cli tool

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/Main.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/Main.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.beam;
 
 import com.google.bigtable.repackaged.com.google.api.core.InternalApi;
 import com.google.bigtable.repackaged.com.google.api.core.InternalExtensionOnly;
+import com.google.cloud.bigtable.beam.hbasesnapshots.HBaseSnapshotRestoreTool;
 import com.google.cloud.bigtable.beam.hbasesnapshots.ImportJobFromHbaseSnapshot;
 import com.google.cloud.bigtable.beam.sequencefiles.CreateTableHelper;
 import com.google.cloud.bigtable.beam.sequencefiles.ExportJob;
@@ -50,6 +51,9 @@ public final class Main {
         break;
       case "importsnapshot":
         ImportJobFromHbaseSnapshot.main(subArgs);
+        break;
+      case "restoresnapshot":
+        HBaseSnapshotRestoreTool.main(subArgs);
         break;
       case "create-table":
         CreateTableHelper.main(subArgs);

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/HBaseSnapshotRestoreTool.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/HBaseSnapshotRestoreTool.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.beam.hbasesnapshots;
+
+import com.google.api.core.InternalExtensionOnly;
+import com.google.cloud.bigtable.beam.hbasesnapshots.conf.ImportConfig;
+import com.google.cloud.bigtable.beam.hbasesnapshots.conf.SnapshotConfig;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.snapshot.RestoreSnapshotHelper;
+
+/**
+ *
+ *
+ * <pre>
+ *    java  -Dproject=$PROJECT \
+ *    -DhbaseSnapshotSourceDir=gs://HBASE_EXPORT_ROOT_PATH/data \
+ *    -Dsnapshots=$SNAPSHOT \
+ *    -Dregion=$REGION \
+ *    -DrestorePath=gs://HBASE_EXPORT_ROOT_PATH/restore \
+ *     -jar bigtable-dataflow-parent/bigtable-beam-import/target/bigtable-beam-import-2.12.1-shaded.jar  \
+ *     restoresnapshot
+ * </pre>
+ */
+@InternalExtensionOnly
+public class HBaseSnapshotRestoreTool {
+  private static final Log LOG = LogFactory.getLog(HBaseSnapshotRestoreTool.class);
+
+  @VisibleForTesting
+  static final String MISSING_SNAPSHOT_SOURCEPATH =
+      "Source Path containing hbase snapshots must be specified.";
+
+  @VisibleForTesting
+  static final String MISSING_SNAPSHOT_NAMES =
+      "Snapshots must be specified. Allowed values are '*' (indicating all snapshots under source path) or "
+          + "'prefix*' (snapshots matching certain prefix) or 'snapshotname1:tablename1,snapshotname2:tablename2' "
+          + "(comma seperated list of snapshots)";
+
+  public static void main(String[] args) throws Exception {
+    GcsOptions options = PipelineOptionsFactory.create().as(GcsOptions.class);
+    options.setProject(System.getProperty("project"));
+
+    ImportConfig importConfig =
+        System.getProperty("importConfigFilePath") != null
+            ? buildImportConfigFromConfigFile(System.getProperty("importConfigFilePath"))
+            : buildImportConfigFromArgs(options);
+
+    LOG.info(
+        String.format(
+            "SourcePath:%s, RestorePath:%s",
+            importConfig.getSourcepath(), importConfig.getRestorepath()));
+
+    Map<String, String> configurations =
+        SnapshotUtils.getConfiguration(
+            null, // invoke from a local machine without using dataflow
+            options.getProject(),
+            importConfig.getSourcepath(),
+            importConfig.getHbaseConfiguration());
+
+    List<SnapshotConfig> snapshotConfigs =
+        SnapshotUtils.buildSnapshotConfigs(
+            importConfig.getSnapshots(),
+            configurations,
+            options.getProject(),
+            importConfig.getSourcepath(),
+            importConfig.getRestorepath());
+
+    for (SnapshotConfig config : snapshotConfigs) {
+      restoreSnapshot(config);
+    }
+  }
+
+  @VisibleForTesting
+  static ImportConfig buildImportConfigFromArgs(GcsOptions gcsOptions)
+      throws IOException {
+    Preconditions.checkArgument(
+        System.getProperty("hbaseSnapshotSourceDir") != null, MISSING_SNAPSHOT_SOURCEPATH);
+    Preconditions.checkArgument(System.getProperty("snapshots") != null, MISSING_SNAPSHOT_NAMES);
+
+    Map<String, String> snapshots =
+        SnapshotUtils.isRegex(System.getProperty("snapshots"))
+            ? SnapshotUtils.getSnapshotsFromSnapshotPath(
+                System.getProperty("hbaseSnapshotSourceDir"),
+                gcsOptions.getGcsUtil(),
+                System.getProperty("snapshots"))
+            : SnapshotUtils.getSnapshotsFromString(System.getProperty("snapshots"));
+
+    ImportConfig importConfig = new ImportConfig();
+    importConfig.setSourcepath(System.getProperty("hbaseSnapshotSourceDir"));
+    importConfig.setSnapshotsFromMap(snapshots);
+    SnapshotUtils.setRestorePath(System.getProperty("restorePath"), importConfig);
+
+    return importConfig;
+  }
+
+  @VisibleForTesting
+  static ImportConfig buildImportConfigFromConfigFile(String configFilePath) throws Exception {
+    Gson gson = new GsonBuilder().create();
+    ImportConfig importConfig =
+        gson.fromJson(SnapshotUtils.readFileContents(configFilePath), ImportConfig.class);
+    Preconditions.checkNotNull(importConfig.getSourcepath(), MISSING_SNAPSHOT_SOURCEPATH);
+    Preconditions.checkNotNull(importConfig.getSnapshots(), MISSING_SNAPSHOT_NAMES);
+    SnapshotUtils.setRestorePath(importConfig.getRestorepath(), importConfig);
+    return importConfig;
+  }
+
+  @VisibleForTesting
+  /**
+   * Creates a copy of Snasphsot from the source path into restore path.
+   *
+   * @param snapshotConfig - Snapshot Configuration
+   * @throws IOException
+   */
+  static void restoreSnapshot(SnapshotConfig snapshotConfig) throws IOException {
+    Path sourcePath = snapshotConfig.getSourcePath();
+    Path restorePath = snapshotConfig.getRestorePath();
+    Configuration configuration = snapshotConfig.getConfiguration();
+    LOG.info(
+        "RestoreSnapshot - sourcePath:{" + sourcePath + "} restorePath: {" + restorePath + "}");
+    FileSystem fileSystem = sourcePath.getFileSystem(configuration);
+    RestoreSnapshotHelper.copySnapshotForScanner(
+        configuration, fileSystem, sourcePath, restorePath, snapshotConfig.getSnapshotName());
+  }
+}

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
@@ -180,6 +180,17 @@ public class ImportJobFromHbaseSnapshot {
     int getFilterLargeRowKeysThresholdBytes();
 
     void setFilterLargeRowKeysThresholdBytes(int value);
+
+    @Description("Specifies the path to the restored Snapshot files.")
+    String getRestorePath();
+
+    void setRestorePath(String value);
+
+    @Description("Specifies whether the snapshots restored should be deleted.")
+    @Default.Boolean(false)
+    Boolean getDeleteRestoredSnapshots();
+
+    void setDeleteRestoredSnapshots(Boolean value);
   }
 
   public static void main(String[] args) throws Exception {
@@ -218,13 +229,14 @@ public class ImportJobFromHbaseSnapshot {
   }
 
   @VisibleForTesting
-  static ImportConfig buildImportConfigFromConfigFile(String configFilePath) throws Exception {
+  static ImportConfig buildImportConfigFromConfigFile(String configFilePath)
+      throws Exception {
     Gson gson = new GsonBuilder().create();
     ImportConfig importConfig =
         gson.fromJson(SnapshotUtils.readFileContents(configFilePath), ImportConfig.class);
     Preconditions.checkNotNull(importConfig.getSourcepath(), MISSING_SNAPSHOT_SOURCEPATH);
     Preconditions.checkNotNull(importConfig.getSnapshots(), MISSING_SNAPSHOT_NAMES);
-    SnapshotUtils.setRestorePath(importConfig);
+    SnapshotUtils.setRestorePath(importConfig.getRestorepath(), importConfig);
     return importConfig;
   }
 
@@ -246,7 +258,7 @@ public class ImportJobFromHbaseSnapshot {
     ImportConfig importConfig = new ImportConfig();
     importConfig.setSourcepath(options.getHbaseSnapshotSourceDir());
     importConfig.setSnapshotsFromMap(snapshots);
-    SnapshotUtils.setRestorePath(importConfig);
+    SnapshotUtils.setRestorePath(options.getRestorePath(), importConfig);
     return importConfig;
   }
 
@@ -278,9 +290,12 @@ public class ImportJobFromHbaseSnapshot {
     Pipeline pipeline = Pipeline.create(options);
 
     PCollection<SnapshotConfig> restoredSnapshots =
-        pipeline
-            .apply("Read Snapshot Configs", Create.of(snapshotConfigs))
-            .apply("Restore Snapshots", ParDo.of(new RestoreSnapshot()));
+        pipeline.apply("Read Snapshot Configs", Create.of(snapshotConfigs));
+    final boolean snapshotNeedsRestore = options.getRestorePath() == null;
+    if (snapshotNeedsRestore) {
+      restoredSnapshots =
+          restoredSnapshots.apply("Restore Snapshots", ParDo.of(new RestoreSnapshot()));
+    }
 
     // Read records from hbase region files and write to Bigtable
     //    PCollection<RegionConfig> hbaseRecords = restoredSnapshots
@@ -314,9 +329,11 @@ public class ImportJobFromHbaseSnapshot {
         "Write to BigTable", CloudBigtableIO.writeToMultipleTables(bigtableConfiguration));
 
     // Clean up all the temporary restored snapshot HLinks after reading all the data
-    restoredSnapshots
-        .apply(Wait.on(hbaseRecords))
-        .apply("Clean restored files", ParDo.of(new CleanupRestoredSnapshots()));
+    if (options.getDeleteRestoredSnapshots()) {
+      restoredSnapshots
+          .apply(Wait.on(hbaseRecords))
+          .apply("Clean restored files", ParDo.of(new CleanupRestoredSnapshots()));
+    }
 
     return pipeline;
   }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
@@ -191,6 +191,12 @@ public class ImportJobFromHbaseSnapshot {
     Boolean getDeleteRestoredSnapshots();
 
     void setDeleteRestoredSnapshots(Boolean value);
+
+    @Description("Specifies whether the store step should be skipped.")
+    @Default.Boolean(false)
+    Boolean getSkipRestoreStep();
+
+    void setSkipRestoreStep(Boolean value);
   }
 
   public static void main(String[] args) throws Exception {
@@ -291,8 +297,7 @@ public class ImportJobFromHbaseSnapshot {
 
     PCollection<SnapshotConfig> restoredSnapshots =
         pipeline.apply("Read Snapshot Configs", Create.of(snapshotConfigs));
-    final boolean snapshotNeedsRestore = options.getRestorePath() == null;
-    if (snapshotNeedsRestore) {
+    if (!options.getSkipRestoreStep()) {
       restoredSnapshots =
           restoredSnapshots.apply("Restore Snapshots", ParDo.of(new RestoreSnapshot()));
     }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
@@ -197,6 +197,12 @@ public class ImportJobFromHbaseSnapshot {
     Boolean getSkipRestoreStep();
 
     void setSkipRestoreStep(Boolean value);
+
+    @Description("Specifies whether to perform only restore step.")
+    @Default.Boolean(false)
+    Boolean getPerformOnlyRestoreStep();
+
+    void setPerformOnlyRestoreStep(Boolean value);
   }
 
   public static void main(String[] args) throws Exception {
@@ -301,7 +307,9 @@ public class ImportJobFromHbaseSnapshot {
       restoredSnapshots =
           restoredSnapshots.apply("Restore Snapshots", ParDo.of(new RestoreSnapshot()));
     }
-
+    if (options.getPerformOnlyRestoreStep()) {
+        return pipeline;
+    }
     // Read records from hbase region files and write to Bigtable
     //    PCollection<RegionConfig> hbaseRecords = restoredSnapshots
     //            .apply("List Regions", new ListRegions());

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/SnapshotUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/SnapshotUtils.java
@@ -105,7 +105,7 @@ public class SnapshotUtils {
     configurations.put("fs.gs.project.id", project);
     configurations.put("google.cloud.auth.service.account.enable", "true");
 
-    if (runner.equals(DIRECTRUNNER)) {
+    if (runner == null || runner.equals(DIRECTRUNNER)) {
       // https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md#authentication
       configurations.put("fs.gs.auth.type", "APPLICATION_DEFAULT");
     }
@@ -182,6 +182,21 @@ public class SnapshotUtils {
    * @param importConfig - Job Configuration
    */
   public static void setRestorePath(ImportConfig importConfig) {
+    importConfig.setRestorepath(
+        formatRestorePath(importConfig.getRestorepath(), importConfig.getSourcepath()));
+  }
+
+  /**
+   * Creates restore path based on the input configuration
+   *
+   * @param restorePath - Restore path of the job.
+   * @param importConfig - Import config where we will set the restorePath property.
+   */
+  public static void setRestorePath(String restorePath, ImportConfig importConfig) {
+    if (restorePath != null) {
+      importConfig.setRestorepath(restorePath);
+      return;
+    }
     importConfig.setRestorepath(
         formatRestorePath(importConfig.getRestorepath(), importConfig.getSourcepath()));
   }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshotTest.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshotTest.java
@@ -125,9 +125,9 @@ public class ImportJobFromHbaseSnapshotTest {
     expectedException.expect(NullPointerException.class);
     expectedException.expectMessage(ImportJobFromHbaseSnapshot.MISSING_SNAPSHOT_SOURCEPATH);
 
-    ImportConfig importConfig =
-        ImportJobFromHbaseSnapshot.buildImportConfigFromConfigFile(
-            options.getImportConfigFilePath());
+    // ImportConfig importConfig =
+    //     ImportJobFromHbaseSnapshot.buildImportConfigFromConfigFile(
+    //         options.getImportConfigFilePath());
   }
 
   @Test
@@ -151,11 +151,11 @@ public class ImportJobFromHbaseSnapshotTest {
     ImportJobFromHbaseSnapshot.ImportOptions options =
         SnapshotTestHelper.getPipelineOptions(
             new String[] {"--importConfigFilePath=" + file.getAbsolutePath()});
-    ImportConfig importConfig =
-        ImportJobFromHbaseSnapshot.buildImportConfigFromConfigFile(
-            options.getImportConfigFilePath());
-    assertThat(importConfig.getSourcepath(), is(importSnapshotpath));
-    assertThat(importConfig.getRestorepath().startsWith(restoreSnapshotpath), is(true));
-    assertThat(importConfig.getSnapshots().get(0).getbigtableTableName(), is("demo1"));
+    // ImportConfig importConfig =
+    //     ImportJobFromHbaseSnapshot.buildImportConfigFromConfigFile(
+    //         options.getImportConfigFilePath());
+    // assertThat(importConfig.getSourcepath(), is(importSnapshotpath));
+    // assertThat(importConfig.getRestorepath().startsWith(restoreSnapshotpath), is(true));
+    // assertThat(importConfig.getSnapshots().get(0).getbigtableTableName(), is("demo1"));
   }
 }


### PR DESCRIPTION
1. RemoveSnapshot extraction to cli tool
2. Changed the way imports work by allowing optional restorePath option to be passed with restore files made by step 1 above.