### PR TITLE
Checkpoint completed region-ranges and use them to resume imports

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -310,9 +310,31 @@ limitations under the License.
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-shaded-client</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>bigtable-hbase-1.x-shaded</artifactId>
+          <groupId>${project.groupId}</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>bigtable-hbase-2.x-shaded</artifactId>
+      <version>2.12.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- Test Group -->
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
@@ -42,6 +42,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
@@ -180,6 +181,10 @@ public class ImportJobFromHbaseSnapshot {
     int getFilterLargeRowKeysThresholdBytes();
 
     void setFilterLargeRowKeysThresholdBytes(int value);
+
+    @Description("If set, uses this path to read and write checkpoint files.")
+    String getCheckpointPath();
+    void setCheckpointPath(String value);
   }
 
   public static void main(String[] args) throws Exception {
@@ -310,6 +315,7 @@ public class ImportJobFromHbaseSnapshot {
                     options.getFilterLargeCellsThresholdBytes(),
                     options.getFilterLargeRowKeys(),
                     options.getFilterLargeRowKeysThresholdBytes(),
+                    options.getCheckpointPath(),
                     bigtableConfiguration));
 
     // Clean up all the temporary restored snapshot HLinks after reading all the data

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
@@ -471,7 +471,7 @@ public class EndToEndIT {
     importOpts.setSnapshots(importOpts.getSnapshotName() + ":" + tableId);
     importOpts.setSnapshotName(null);
     importOpts.setRunner(DirectRunner.class);
-    //importOpts.setCheckpointPath("gs://igorbernstein-dev3/checkpoint-dir");
+    importOpts.setCheckpointPath("gs://igorbernstein-dev3/checkpoint-dir");
 
     ImportConfig config = ImportJobFromHbaseSnapshot.buildImportConfigFromPipelineOptions(
         importOpts, importOpts.as(

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
@@ -20,6 +20,7 @@ import com.google.api.services.storage.model.StorageObject;
 import com.google.bigtable.repackaged.com.google.gson.Gson;
 import com.google.cloud.bigtable.beam.hbasesnapshots.ImportJobFromHbaseSnapshot.ImportOptions;
 import com.google.cloud.bigtable.beam.hbasesnapshots.conf.HBaseSnapshotInputConfigBuilder;
+import com.google.cloud.bigtable.beam.hbasesnapshots.conf.ImportConfig;
 import com.google.cloud.bigtable.beam.hbasesnapshots.dofn.CleanupHBaseSnapshotRestoreFiles;
 import com.google.cloud.bigtable.beam.sequencefiles.HBaseResultToMutationFn;
 import com.google.cloud.bigtable.beam.test_env.EnvSetup;
@@ -48,9 +49,11 @@ import java.util.stream.StreamSupport;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.runners.direct.DirectRunner;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.extensions.gcp.util.GcsUtil;
 import org.apache.beam.sdk.extensions.gcp.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -227,6 +230,7 @@ public class EndToEndIT {
     properties.applyTo(importPipelineOpts);
 
     ImportOptions importOpts = importPipelineOpts.as(ImportOptions.class);
+    // importOpts.setRunner(DirectRunner.class);
 
     // setup Bigtable options
     importOpts.setBigtableProject(StaticValueProvider.of(properties.getProjectId()));
@@ -445,6 +449,63 @@ public class EndToEndIT {
 
     // Verify the import using the sync job
     SyncTableOptions syncOpts = createSyncTableOptions();
+
+    PipelineResult result = SyncTableJob.buildPipeline(syncOpts).run();
+    state = result.waitUntilFinish();
+    Assert.assertEquals(State.DONE, state);
+
+    // Read the output files and validate that there are no mismatches.
+    Assert.assertEquals(0, readMismatchesFromOutputFiles().size());
+
+    // Validate the counters.
+    Map<String, Long> counters = getCountMap(result);
+    Assert.assertEquals(counters.get("ranges_matched"), (Long) 100L);
+    Assert.assertEquals(counters.get("ranges_not_matched"), (Long) 0L);
+  }
+
+  @Test
+  public void testHBaseSnapshotImport2() throws Exception {
+    // Start import
+    ImportOptions importOpts = createImportOptions();
+    // Force new version
+    importOpts.setSnapshots(importOpts.getSnapshotName() + ":" + tableId);
+    importOpts.setSnapshotName(null);
+    importOpts.setRunner(DirectRunner.class);
+    //importOpts.setCheckpointPath("gs://igorbernstein-dev3/checkpoint-dir");
+
+    ImportConfig config = ImportJobFromHbaseSnapshot.buildImportConfigFromPipelineOptions(
+        importOpts, importOpts.as(
+            GcsOptions.class));
+
+    // run pipeline
+    State state = ImportJobFromHbaseSnapshot.buildPipelineWithMultipleSnapshots(importOpts, config).run().waitUntilFinish();
+    Assert.assertEquals(State.DONE, state);
+
+    // check that the .restore dir used for temp files has been removed
+    // The restore directory is stored relative to the snapshot directory and contains the job name
+    String bucket = GcsPath.fromUri(hbaseSnapshotDir).getBucket();
+    String restorePathPrefix =
+        CleanupHBaseSnapshotRestoreFiles.getListPrefix(HBaseSnapshotInputConfigBuilder.RESTORE_DIR);
+    List<StorageObject> allObjects = new ArrayList<>();
+    String nextToken;
+    do {
+      Objects objects = gcsUtil.listObjects(bucket, restorePathPrefix, null);
+      List<StorageObject> items = objects.getItems();
+      if (items != null) {
+        allObjects.addAll(items);
+      }
+      nextToken = objects.getNextPageToken();
+    } while (nextToken != null);
+
+    List<StorageObject> myObjects =
+        allObjects.stream()
+            .filter(o -> o.getName().contains(importOpts.getJobName()))
+            .collect(Collectors.toList());
+    Assert.assertTrue("Restore directory wasn't deleted", myObjects.isEmpty());
+
+    // Verify the import using the sync job
+    SyncTableOptions syncOpts = createSyncTableOptions();
+    syncOpts.setRunner(DirectRunner.class);
 
     PipelineResult result = SyncTableJob.buildPipeline(syncOpts).run();
     state = result.waitUntilFinish();

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -975,11 +976,13 @@ public class CloudBigtableIO {
      * <p>NOTE: This method does not create a new table in Cloud Bigtable. The table must already
      * exist.
      *
-     * @param context The context for the {@link DoFn}.
+     * @param element The element for the {@link DoFn}.
      */
     @ProcessElement
-    public void processElement(ProcessContext context) throws Exception {
-      KV<String, Iterable<Mutation>> element = context.element();
+    public void processElement(
+        @Element KV<String, Iterable<Mutation>> element,
+        @Nullable ProcessContext context) throws Exception {
+
       BufferedMutator mutator = getMutator(context, element.getKey());
       try {
         for (Mutation mutation : element.getValue()) {
@@ -1002,7 +1005,7 @@ public class CloudBigtableIO {
     }
 
     @FinishBundle
-    public void finishBundle(FinishBundleContext c) throws Exception {
+    public void finishBundle(@Nullable FinishBundleContext c) throws Exception {
       try {
         for (BufferedMutator bufferedMutator : mutators.values()) {
           try {


### PR DESCRIPTION
At a high level this works as following:

- We fuse the read and write step (to guarantee that all writes have completed in FinishBundle of the read step)
- While reading, keep track of the ranges we've successfully read + written (in `regionProgress`).  In runner V1 this will always be the full restriction passed into processElement, but runners that fully implement SDF may split the restriction further in processElement and thus we need more granular tracking like implemented here.
- In FinishBundle we write out the ranges to the checkpoint path.  The filename is in the format `{prefix}/{encoded-region-name}-{sha-of-key-range}.SUCCESS`

Now if the job fails and restarts:
- When processing a RegionConfig, look for any files that match the prefix `{prefix}/{encoded-region-name}-*`.  This may be more ranges than the restriction specifies but thats ok.
- Subtract the ranges from above from the full range specified by the restriction.
- Read the ranges specified by the result of the subtraction.